### PR TITLE
打刻ページの修正

### DIFF
--- a/src/pages/api/member_attendance_get.ts
+++ b/src/pages/api/member_attendance_get.ts
@@ -1,0 +1,17 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../../firebase";
+
+const getAirportAPI = async (_req: NextApiRequest, res: NextApiResponse) => {
+  const querySnapshot = await getDocs(collection(db, "users-attendance"));
+
+  const user= [];
+  querySnapshot.forEach((doc) => {
+    const userdata = doc.data();
+    user.push(userdata);
+  });
+
+  return res.status(200).json(user);
+};
+
+export default getAirportAPI;

--- a/src/pages/api/user_get.ts
+++ b/src/pages/api/user_get.ts
@@ -1,15 +1,26 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { collection, getDocs } from "firebase/firestore";
 import { db } from "../../firebase";
+import { doc, getDoc,getDocs,collection } from "firebase/firestore";
 
 const getAirportAPI = async (_req: NextApiRequest, res: NextApiResponse) => {
-  const querySnapshot = await getDocs(collection(db, "users"));
-
-  const user= [];
+  console.log("req", _req.body.id);
+//idがある場合は指定idのuser情報を取得
+  const user = [];
+  if (_req.body.id) {
+    const attendanceRef = doc(db, "users", _req.body.id);
+    const docSnap = await getDoc(attendanceRef);
+    console.log("doc", docSnap.data());
+    user.push(docSnap.data());
+  }
+  //idがない場合は全user情報を取得
+  else{
+const querySnapshot = await getDocs(collection(db, "users"));
   querySnapshot.forEach((doc) => {
     const userdata = doc.data();
     user.push(userdata);
   });
+  }
+  
 
   return res.status(200).json(user);
 };

--- a/src/pages/api/user_post.ts
+++ b/src/pages/api/user_post.ts
@@ -1,0 +1,31 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { db } from "../../firebase";
+import {
+
+  doc,
+  Timestamp,
+  updateDoc,
+
+} from "firebase/firestore";
+
+const getAirportAPI = async (_req: NextApiRequest, res: NextApiResponse) => {
+
+    //statue:trueの場合は入場する
+  if (_req.body.statue) {
+    const users_status = doc(db, "users", _req.body.id);
+    await updateDoc(users_status, {
+      statue: true,
+      enterTime: Timestamp.fromDate(new Date()),
+    });
+  }
+    //statue:trueの場合は退場する
+  else{
+    const users_status = doc(db, "users", _req.body.id);
+    await updateDoc(users_status, {
+      statue: false,
+      exitTime: Timestamp.fromDate(new Date()),
+    });
+  }
+};
+
+export default getAirportAPI;

--- a/src/pages/member-attendance-log.tsx
+++ b/src/pages/member-attendance-log.tsx
@@ -2,14 +2,11 @@ import Layout from "@/components/Layout";
 import useSWR from "swr";
 
 export default function MemberAttendanceLog() {
-
-
   const fetcher1 = (resource: any, init: any) =>
-  fetch(resource, init).then((res) => res.json());
-  const { data } = useSWR( "/api/user_get", fetcher1);
-  console.log("datam",data)
+    fetch(resource, init).then((res) => res.json());
+  const { data } = useSWR("/api/user_get", fetcher1);
+  console.log("datam", data);
 
-  
   return (
     <>
       <Layout>

--- a/src/pages/member-attendance-log.tsx
+++ b/src/pages/member-attendance-log.tsx
@@ -6,7 +6,7 @@ export default function MemberAttendanceLog() {
 
   const fetcher1 = (resource: any, init: any) =>
   fetch(resource, init).then((res) => res.json());
-  const { data } = useSWR( "/api/user-get", fetcher1);
+  const { data } = useSWR( "/api/user_get", fetcher1);
   console.log("datam",data)
 
   

--- a/src/pages/member-attendance.tsx
+++ b/src/pages/member-attendance.tsx
@@ -19,7 +19,18 @@ export default function MemberAttendance() {
   const [errormessage, setErrormessage] = useState("");
   const [notice, setNotice] = useState("");
   const [timenotice, setTimenotice] = useState("");
-  const Time=Times().year + "/" + Times().mon + "/" +Times().day + "  " + Times().hour + ":" +Times().min + ":" + Times().sec;
+  const Time =
+    Times().year +
+    "/" +
+    Times().mon +
+    "/" +
+    Times().day +
+    "  " +
+    Times().hour +
+    ":" +
+    Times().min +
+    ":" +
+    Times().sec;
 
   const Enter = async () => {
     setErrormessage("");
@@ -35,14 +46,17 @@ export default function MemberAttendance() {
       if (docSnap.data().statue) {
         setErrormessage("エラー！！既入場しています。");
       } else {
-        await addDoc(collection(db, "users-attendance"), {
-          id: id,
-          enterTime: Timestamp.fromDate(new Date()),
-          exitTime: "",
-        });
+        // await addDoc(collection(db, "users-attendance"), {
+        //   id: id,
+        //   enterTime: Timestamp.fromDate(new Date()),
+        //   exitTime: "",
+        // });
         //status:trueを保存
         const users_status = doc(db, "users", id);
-        await updateDoc(users_status, { statue: true });
+        await updateDoc(users_status, {
+          statue: true,
+          enterTime: Timestamp.fromDate(new Date()),
+        });
         const usersSnap = await getDoc(users_status);
         if (usersSnap.exists()) {
           setAttendanceTime(Time);
@@ -58,7 +72,7 @@ export default function MemberAttendance() {
         }, 3000);
       }
     } else {
-      setErrormessage("会員番号が間違っています")
+      setErrormessage("会員番号が間違っています");
     }
   };
 
@@ -72,16 +86,17 @@ export default function MemberAttendance() {
     const docSnap = await getDoc(attendanceRef);
     if (docSnap.exists()) {
       if (docSnap.data().statue) {
-        await addDoc(collection(db, "users-attendance"), {
-          id: id,
-          enterTime: "",
-          exitTime: Timestamp.fromDate(new Date()),
-        });
-        //status:trueを保存
+        //status:falseを保存
         const users_status = doc(db, "users", id);
-        await updateDoc(users_status, { statue: false });
         const usersSnap = await getDoc(users_status);
         if (usersSnap.exists()) {
+          //enterTime=usersSnap.data().enterTime
+          await addDoc(collection(db, "users-attendance"), {
+            id: id,
+            enterTime: usersSnap.data().enterTime,
+            exitTime: Timestamp.fromDate(new Date()),
+          });
+          await updateDoc(users_status, { statue: false,enterTime:""});
           setAttendanceTime(Time);
           setNotice(`${usersSnap.data().name}さんが退場しました。`);
           setTimenotice("3秒後にリセットされます");
@@ -96,7 +111,7 @@ export default function MemberAttendance() {
         setErrormessage("エラー！！入場していません。");
       }
     } else {
-      setErrormessage("会員番号が間違っています")
+      setErrormessage("会員番号が間違っています");
     }
   };
 


### PR DESCRIPTION
## Issueのリンク
- 


## やったこと(What,How)
- 打刻データの持ち方を修正（入場と退場を同じオブジェクトに挿入）
-apiルートを作成
  users取得：id指定と指定なしの両方の分岐を実装
  users更新： 入場と退場で分岐


## やらないこと
- 

## できるようになること（ユーザ目線）(Why,Who)
- 


## できなくなること（ユーザ目線）


## 動作確認


## その他
-
