### PR TITLE
個人の入退場データ一覧

### DIFF
--- a/src/pages/member-attendance-log.tsx
+++ b/src/pages/member-attendance-log.tsx
@@ -1,8 +1,6 @@
 import Layout from "@/components/Layout";
 import useSWR from "swr";
 import {
-  doc,
-  getDoc,
   getDocs,
   collection,
   where,
@@ -12,10 +10,9 @@ import { db } from "../firebase";
 import { useRef, useState } from "react";
 
 export const getServerSideProps = async (id) => {
-  console.log("SSR", id.query);
   const user: any = [];
   const useRef = collection(db, "users-attendance");
-  const q = query(useRef, where("id", "==", "3547"));
+  const q = query(useRef, where("id", "==", `${id.query.id}`));
   const querySnapshot = await getDocs(q);
   querySnapshot.forEach((doc) => {
     user.push(doc.data());
@@ -26,9 +23,6 @@ export const getServerSideProps = async (id) => {
     u.exitTime = u.exitTime.toDate();
   });
 
-  // });
-
-  // console.log("parse");
   return {
     props: {
       //javascriptオブジェクト
@@ -38,79 +32,100 @@ export const getServerSideProps = async (id) => {
 };
 
 export default function MemberAttendanceLog({ data }) {
-  if (!data) return;
-  // console.log("data", JSON.parse(data));
-  const datam = JSON.parse(data);
+  const [month, setMonth] = useState(new Date().getMonth() + 1);
+  const [year, setYear] = useState(new Date().getFullYear());
 
+  if (!data) return;
+  const datam = JSON.parse(data);
+  //取得したデータに新たなオブジェクトdateを追加して00/00の形で保存
   datam.map((t) => {
-    // t.date = `${new Date(t.enterTime).getMonth}`/`${new Date(t.enterTime).getDate()}`;
     t.date = `${new Date(t.enterTime).getMonth() + 1}/${new Date(
       t.enterTime
     ).getDate()}`;
   });
-  console.log("datm", datam);
 
-  // const parseData = JSON.parse(data);
-  // const enterTime=parseData[0].enterTime
-  // console.log()
-  // console.log("timee", new Date(enterTime).getDay());
-
-  // console.log("javascript",Date.now())
-  // console.log(Timestamp.fromDate(new Date()).toDate())
-
-  let today = new Date();
-  let myYear = today.getFullYear();
-  let myMonth = today.getMonth();
-  let lastday = new Date(myYear, myMonth + 1, 0);
+  //最終日計算
+  let lastday = new Date(year, month, 0);
+  //最終日の日付のみ
   lastday = lastday.getDate();
-  // console.log("lastday", lastday);
+
 
   let date = [];
   for (var i = 1; i <= lastday; i++) {
-    let xday = new Date(myYear, myMonth, i);
+    let xday = new Date(year, month, i);
     let xdays = xday.getDay();
-    // console.log("xdays", xdays);
     let weekjp = new Array("日", "月", "火", "水", "木", "金", "土");
     let weeks = weekjp[xdays];
-    date.push({ day: `${myMonth + 1}/${i}`, date: i, weeks: weeks });
+    date.push({ day: `${month}/${i}`, date: i, weeks: weeks });
   }
-  console.log(date);
 
+
+  let datefinish = [];
   date.map((d) => {
     const filterdam = datam.filter((dm) => {
-      // console.log(dm.date,d.day)
       return dm.date === d.day;
     });
-    filterdam.day = d.day;
-    filterdam.weeks = d.weeks;
-    if (!filterdam.enterTime) {
-      filterdam.enterTime = "";
-      filterdam.exitTime = "";
+    if (filterdam.length === 0) {
+      datefinish.push({
+        enterTime: "",
+        exitTime: "",
+        date: d.day,
+        week: d.weeks,
+      });
+    } else {
+      filterdam[0].week = d.weeks;
+      datefinish.push(filterdam[0]);
     }
-    console.log("filter", filterdam);
   });
+
+  //プルダウン用：とりあえず前後10年間表示
+  let pulldownyear = [];
+  for (let i = 2013; i < 2033; i++) {
+    pulldownyear.push(i);
+  }
+  //プルダウン用：1月〜12月
+  let pulldownmonth = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+  const changeYear = (e) => {
+    setYear(e.target.value);
+  };
+
+  const changeMonth = (e) => {
+    console.log(e.target.value);
+    setMonth(e.target.value);
+  };
 
   return (
     <>
       <Layout>
         <p>月次入退場データ</p>
 
-        {/* <p>{data[0].enterTime}</p> */}
-        {/* <p >{ new Date(JSON.parse(data)[0].enterTime.seconds*1000).toLocaleString()}</p> */}
-        {/* {new Date(JSON.parse(data)[0].enterTime.seconds*1000)} */}
-        {/* <p>{new Date(data[0].enterTime.seconds*1000)}</p> */}
         <form action="">
-          <select name="" id="">
-            <option value=""></option>
+          <select name="" id="" value={year} onChange={changeYear}>
+            {pulldownyear.map((y, index) => {
+              return (
+                <option value={y} key={index}>
+                  {y}
+                </option>
+              );
+            })}
           </select>
           年
-          <select name="" id="">
-            <option value=""></option>
+          <select name="" id="" value={month} onChange={changeMonth}>
+            {pulldownmonth.map((m, index) => {
+              return (
+                <option value={m} key={index}>
+                  {m}
+                </option>
+              );
+            })}
           </select>
           月
         </form>
-        <div></div>
-        <table>
+        <div>
+          表示期間:{year}年{month}月
+        </div>
+        <table border={1} style={{ borderCollapse: "collapse" }}>
           <thead>
             <tr>
               <td>日付</td>
@@ -121,10 +136,57 @@ export default function MemberAttendanceLog({ data }) {
             </tr>
           </thead>
           <tbody>
-            {date.map((d, index) => (
+            {datefinish.map((d, index) => (
               <tr key={index}>
                 <td>{d.date}</td>
-                <td>{d.weeks}</td>
+                <td>{d.week}</td>
+
+                <td>
+                  {d.enterTime === ""
+                    ? ""
+                    : `${
+                      new Date(d.enterTime).getMinutes() < 10
+                        ? `${new Date(d.enterTime).getHours()}:0${new Date(
+                            d.enterTime
+                          ).getMinutes()}`
+                        : `${new Date(d.enterTime).getHours()}:${new Date(
+                            d.enterTime
+                          ).getMinutes()}`
+                    }`}
+                </td>
+                <td>
+                  {d.exitTime === ""
+                    ? ""
+                    : `${
+                        new Date(d.exitTime).getMinutes() < 10
+                          ? `${new Date(d.exitTime).getHours()}:0${new Date(
+                              d.exitTime
+                            ).getMinutes()}`
+                          : `${new Date(d.exitTime).getHours()}:${new Date(
+                              d.exitTime
+                            ).getMinutes()}`
+                      }`}
+                </td>
+
+                <td>
+                  {d.enterTime === ""
+                    ? ""
+                    : `${Math.round(
+                        ((new Date(d.exitTime).getTime() -
+                          new Date(d.enterTime).getTime()) /
+                          1000 /
+                          60 /
+                          60) %
+                          24
+                      )}時間  ${Math.round(
+                        ((new Date(d.exitTime).getTime() -
+                          new Date(d.enterTime).getTime()) /
+                          1000 /
+                          60) %
+                          60
+                      )}
+                  分`}
+                </td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Issueのリンク
- https://github.com/Konimado/attendance-system/issues/27


## やったこと(What,How)
- 入退場の一覧データ表示
- プルダウンの変更により年と月を指定できる（初期表示：現在月）
- レンダリング：SSR
- queryによってメンバーのIDを取得して、それをキーにfirestoreからデータを取得



## やらないこと
- 

## できるようになること（ユーザ目線）(Why,Who)
- メンバーの入退場データの一覧を見ることができる


## できなくなること（ユーザ目線）


## 動作確認


## その他
-
